### PR TITLE
[Hotfix] Compre Junto não contabiliza desconto

### DIFF
--- a/src/components/buy-together/services/front-buy-together.adapter.ts
+++ b/src/components/buy-together/services/front-buy-together.adapter.ts
@@ -46,7 +46,7 @@ export class FrontBuyTogetherAdapter {
     const adaptSpecialPrice = (payments: Payment[]): number | null => {
       const pixMethod = payments.find(payment => payment.method === 'pix');
       if (pixMethod) {
-        const specialPrice = product.price * Number(pixMethod.markup);
+        const specialPrice = Number(pixMethod.installment.total);
         return specialPrice;
       }
       return null;


### PR DESCRIPTION
## [Hotfix] Compre Junto não contabiliza desconto

[task link](https://dev.azure.com/doocacom/Platform/_workitems/edit/16949)

### Changes:

- Ajuste no cálculo do preço final do pix.

OBS: necessário subir [esse ajuste](https://github.com/uxshop/storefront-core/pull/145) antes.