### PR TITLE
[Hotfix] Compre Junto não exibe cores vinculadas

### DIFF
--- a/src/components/buy-together/services/front-buy-together.adapter.ts
+++ b/src/components/buy-together/services/front-buy-together.adapter.ts
@@ -135,10 +135,10 @@ export class FrontBuyTogetherAdapter {
     return {
       label: 'Cor',
       placeholder: this.placeholderDisabled,
-      options: listColors?.map(({ balance, id, name, releaseDate }) => ({
+      options: listColors?.map(({ balance, id, name, releaseDate, isSellOutOfStock }) => ({
         name,
         value: id,
-        disabled: this.checkAttributeOptionDisabled({ balance, releaseDate }),
+        disabled: this.checkAttributeOptionDisabled({ balance, releaseDate, isSellOutOfStock }),
       })),
       currentValue: product.color?.id,
       selectType: 'color',
@@ -175,7 +175,12 @@ export class FrontBuyTogetherAdapter {
           if (index === -1)
             return [
               ...acc,
-              { ...objItem, balance: current.balance, releaseDate: current.releaseDate },
+              {
+                ...objItem,
+                balance: current.balance,
+                releaseDate: current.releaseDate,
+                isSellOutOfStock: current.isSellOutOfStock,
+              },
             ];
           return acc;
         },


### PR DESCRIPTION
### Changes: 

- Adição do isSellOutOfStock na geração de options para cores no componente `BuyTogether`.