### PR TITLE
[Hotfix] Compre junto exibindo imagem com zoom

### DIFF
--- a/src/components/ui/front-image/front-image.scss
+++ b/src/components/ui/front-image/front-image.scss
@@ -12,7 +12,7 @@
   img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     opacity: 1;
     transition: opacity 1s;
   }


### PR DESCRIPTION
## [Hotfix] Compre junto exibindo imagem com zoom

[task link](https://dev.azure.com/doocacom/Platform/_workitems/edit/17437)

### Changes:

- Adiciona object-fit contain para conteúdo não esticar na tela.