### PR TITLE
[Task] Tratativa de exibição de preço "A partir de"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 www/
+dist/
 *~
 *.sw[mnpcod]
 *.log

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -130,10 +130,12 @@ export namespace Components {
         "inline": boolean;
         "paymentOptions"?: PaymentOption[];
         "product": IProductCard;
+        "showStartingFrom"?: boolean;
     }
     interface ProductPrice {
         "basePrice": BasePrice;
         "paymentOptions"?: PaymentOption[];
+        "showStartingFrom"?: boolean;
     }
     interface ProductPriceBillet {
         "price": number;
@@ -153,6 +155,7 @@ export namespace Components {
     interface ProductPriceSimple {
         "price": number;
         "priceCompare"?: number;
+        "showStartingFrom"?: boolean;
     }
     interface ShowcaseRelated {
         "buttonLabel": string;
@@ -806,10 +809,12 @@ declare namespace LocalJSX {
         "inline"?: boolean;
         "paymentOptions"?: PaymentOption[];
         "product"?: IProductCard;
+        "showStartingFrom"?: boolean;
     }
     interface ProductPrice {
         "basePrice"?: BasePrice;
         "paymentOptions"?: PaymentOption[];
+        "showStartingFrom"?: boolean;
     }
     interface ProductPriceBillet {
         "price"?: number;
@@ -829,6 +834,7 @@ declare namespace LocalJSX {
     interface ProductPriceSimple {
         "price"?: number;
         "priceCompare"?: number;
+        "showStartingFrom"?: boolean;
     }
     interface ShowcaseRelated {
         "buttonLabel"?: string;

--- a/src/components/live-shop/services/live-shop.service.ts
+++ b/src/components/live-shop/services/live-shop.service.ts
@@ -11,7 +11,15 @@ export class LiveShopHandler {
   private async getProducts() {
     const productIds = this.liveShopData.products.map(product => product.productId);
     return await ProductService.getList({
-      fields: ['name', 'images { src }', 'price', 'priceCompare', 'productId', 'slug'],
+      fields: [
+        'name',
+        'images { src }',
+        'price',
+        'priceCompare',
+        'productId',
+        'slug',
+        'hasPriceRange',
+      ],
       filter: { productIds, page: 0, first: productIds.length },
     });
   }
@@ -39,6 +47,7 @@ export class LiveShopHandler {
         slug: node.slug,
         show: status && status !== 'hidden',
         highlight: status === 'highlighting',
+        showStartingFrom: node.hasPriceRange,
       };
     });
   }

--- a/src/components/ui/highlight-card/highlight-card.scss
+++ b/src/components/ui/highlight-card/highlight-card.scss
@@ -70,7 +70,7 @@
       cursor: pointer;
       .highlight-card-product-cart-action {
         & a {
-          text-decoration: underline var(--fc-color-primary) 1px solid;
+          text-decoration: underline var(--fc-color-primary) 1px solid !important;
         }
       }
     }

--- a/src/components/ui/highlight-card/highlight-card.tsx
+++ b/src/components/ui/highlight-card/highlight-card.tsx
@@ -32,6 +32,7 @@ export class HighlightCard {
               custom-class="highlight-custom-style"
               product={item}
               basePrice={{ price: item.price, priceCompare: item.priceBase }}
+              showStartingFrom={item.showStartingFrom}
               inline
             />
             <div class="highlight-card-product-cart-action">

--- a/src/components/ui/product-card/product-card.tsx
+++ b/src/components/ui/product-card/product-card.tsx
@@ -15,6 +15,7 @@ export class ProductCard {
   @Prop({ mutable: true }) product: IProductCard;
   @Prop() basePrice: BasePrice;
   @Prop() paymentOptions?: PaymentOption[] = [];
+  @Prop() showStartingFrom?: boolean = false;
 
   getClassWithInline(className: string) {
     const prosForClass = { '-inline': this.inline };
@@ -32,7 +33,11 @@ export class ProductCard {
           />
           <div class="info">
             <span class="title">{this.product?.name}</span>
-            <product-price basePrice={this.basePrice} paymentOptions={this.paymentOptions} />
+            <product-price
+              basePrice={this.basePrice}
+              paymentOptions={this.paymentOptions}
+              showStartingFrom={this.showStartingFrom}
+            />
           </div>
         </div>
       </Host>

--- a/src/components/ui/product-card/readme.md
+++ b/src/components/ui/product-card/readme.md
@@ -5,13 +5,14 @@
 
 ## Properties
 
-| Property         | Attribute      | Description | Type              | Default     |
-| ---------------- | -------------- | ----------- | ----------------- | ----------- |
-| `basePrice`      | --             |             | `BasePrice`       | `undefined` |
-| `customClass`    | `custom-class` |             | `string`          | `''`        |
-| `inline`         | `inline`       |             | `boolean`         | `false`     |
-| `paymentOptions` | --             |             | `PaymentOption[]` | `[]`        |
-| `product`        | --             |             | `IProductCard`    | `undefined` |
+| Property           | Attribute            | Description | Type              | Default     |
+| ------------------ | -------------------- | ----------- | ----------------- | ----------- |
+| `basePrice`        | --                   |             | `BasePrice`       | `undefined` |
+| `customClass`      | `custom-class`       |             | `string`          | `''`        |
+| `inline`           | `inline`             |             | `boolean`         | `false`     |
+| `paymentOptions`   | --                   |             | `PaymentOption[]` | `[]`        |
+| `product`          | --                   |             | `IProductCard`    | `undefined` |
+| `showStartingFrom` | `show-starting-from` |             | `boolean`         | `false`     |
 
 
 ## Dependencies

--- a/src/components/ui/product-price/product-price.scss
+++ b/src/components/ui/product-price/product-price.scss
@@ -14,6 +14,10 @@
 .payment-option {
   font-size: 14px;
 
+  .starting-from {
+    font-size: 12px;
+  }
+
   .price-compare {
     text-decoration: line-through;
     color: var(--fc-color-light-text-secondary);

--- a/src/components/ui/product-price/product-price.tsx
+++ b/src/components/ui/product-price/product-price.tsx
@@ -10,10 +10,15 @@ import { BasePrice, PaymentOption } from './product-price.type';
 export class ProductPrice {
   @Prop() basePrice: BasePrice;
   @Prop() paymentOptions?: PaymentOption[];
+  @Prop() showStartingFrom?: boolean = false;
 
   private componentMap = {
     simple: (option: PaymentOption) => (
-      <product-price-simple price={option.price} priceCompare={option.priceCompare} />
+      <product-price-simple
+        price={option.price}
+        priceCompare={option.priceCompare}
+        showStartingFrom={this.showStartingFrom}
+      />
     ),
     billet: (option: PaymentOption) => (
       <product-price-billet price={option.price} priceCompare={option.priceCompare} />

--- a/src/components/ui/product-price/readme.md
+++ b/src/components/ui/product-price/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property         | Attribute | Description | Type              | Default     |
-| ---------------- | --------- | ----------- | ----------------- | ----------- |
-| `basePrice`      | --        |             | `BasePrice`       | `undefined` |
-| `paymentOptions` | --        |             | `PaymentOption[]` | `undefined` |
+| Property           | Attribute            | Description | Type              | Default     |
+| ------------------ | -------------------- | ----------- | ----------------- | ----------- |
+| `basePrice`        | --                   |             | `BasePrice`       | `undefined` |
+| `paymentOptions`   | --                   |             | `PaymentOption[]` | `undefined` |
+| `showStartingFrom` | `show-starting-from` |             | `boolean`         | `false`     |
 
 
 ## Dependencies

--- a/src/components/ui/product-price/snippets/simple/product-price-simple.tsx
+++ b/src/components/ui/product-price/snippets/simple/product-price-simple.tsx
@@ -11,6 +11,7 @@ import { BasePrice } from '../../product-price.type';
 export class ProductPriceSimple implements BasePrice {
   @Prop() price: number;
   @Prop() priceCompare?: number;
+  @Prop() showStartingFrom?: boolean = false;
 
   render() {
     const formattedPrice = currencyFormat(this.price);
@@ -18,7 +19,10 @@ export class ProductPriceSimple implements BasePrice {
 
     return (
       <div class="payment-option payment-option-simple">
-        {formattedCompare && <span class="price-compare">{formattedCompare}</span>}
+        {this.showStartingFrom && <span class="starting-from">A partir de</span>}
+        {formattedCompare && !this.showStartingFrom && (
+          <span class="price-compare">{formattedCompare}</span>
+        )}
         <span class="price-current">
           <span class="highlight">{formattedPrice}</span>
         </span>

--- a/src/components/ui/product-price/snippets/simple/readme.md
+++ b/src/components/ui/product-price/snippets/simple/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property       | Attribute       | Description | Type     | Default     |
-| -------------- | --------------- | ----------- | -------- | ----------- |
-| `price`        | `price`         |             | `number` | `undefined` |
-| `priceCompare` | `price-compare` |             | `number` | `undefined` |
+| Property           | Attribute            | Description | Type      | Default     |
+| ------------------ | -------------------- | ----------- | --------- | ----------- |
+| `price`            | `price`              |             | `number`  | `undefined` |
+| `priceCompare`     | `price-compare`      |             | `number`  | `undefined` |
+| `showStartingFrom` | `show-starting-from` |             | `boolean` | `false`     |
 
 
 ## Dependencies


### PR DESCRIPTION
## [Task] Tratativa de exibição de preço "A partir de"

[task link](https://dev.azure.com/doocacom/Platform/_workitems/edit/21347)

### Changes:

- Adiciona label 'a partir de' quando produto tiver variações com menor preço.

<img width="1262" alt="Captura de Tela 2025-02-14 às 14 28 03" src="https://github.com/user-attachments/assets/ac187740-7bf9-484e-9878-b2e6b223d3a3" />
