### PR TITLE
[Hotfix]: Não exibir produtos relacionados sem estoque no carrinho

### DIFF
--- a/src/components/buy-together/services/front-buy-together.service.ts
+++ b/src/components/buy-together/services/front-buy-together.service.ts
@@ -9,7 +9,6 @@ import { Product } from '@uxshop/storefront-core/dist/modules/buy-together/BuyTo
 import { IInputSelectDataEvent } from '../../../components';
 import { IChangeResult, IFrontBuyTogetherService } from './front-buy-together.type';
 import { FrontBuyTogetherFilter } from './front-buy-together.filter';
-import { FrontBuyTogetherResponse } from './front-buy-together-response';
 
 export class FrontBuyTogetherService implements IFrontBuyTogetherService {
   private buyTogetherPaymentConfig: BuyTogetherPaymentConfig[];
@@ -53,10 +52,14 @@ export class FrontBuyTogetherService implements IFrontBuyTogetherService {
   public async getOnlyPivotProducts(productIds: number[]) {
     const responseData = await BuyTogetherService.getByProductIds(productIds);
     const productsPivot = responseData.flatMap(response => {
-      const adaptedBuyTogether = new FrontBuyTogetherResponse(response).adapterToComponentData(
-        this.buyTogetherPaymentConfig,
-      );
-      return adaptedBuyTogether.getComponentData.products;
+      const adaptedBuyTogether = new FrontBuyTogetherFilter(response)
+        .applyFilters([
+          { key: 'priceless', isActive: false },
+          { key: 'releaseDate', isActive: false },
+          { key: 'balance', isActive: true },
+        ])
+        .adapterToComponentData(this.buyTogetherPaymentConfig);
+      return adaptedBuyTogether?.getComponentData?.products || [];
     });
 
     const filteredProducts = this.filterOutOriginalProducts(productsPivot, productIds);


### PR DESCRIPTION
Aplicação de filtro de estoque no getOnlyPivotProducts para não retornar produto sem estoque e assim atender a showcase que esta exibindo produto sem estoque no carrinho.

Task: https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-storefront/Platform/storefront/2025/sprint%2015?workitem=25270