### PR TITLE
[Hotfix] Falha na exibição do Compre Junto

### DIFF
--- a/dist/types/components/buy-together/services/front-buy-together.service.d.ts
+++ b/dist/types/components/buy-together/services/front-buy-together.service.d.ts
@@ -4,6 +4,7 @@ import { IInputSelectDataEvent } from '../../../components';
 import { IChangeResult, IFrontBuyTogetherService } from './front-buy-together.type';
 export declare class FrontBuyTogetherService implements IFrontBuyTogetherService {
     private buyTogetherPaymentConfig;
+    private configLoaded;
     constructor();
     private loadBuyTogetherPaymentConfig;
     private filterOutOriginalProducts;

--- a/src/components/buy-together/services/front-buy-together.service.ts
+++ b/src/components/buy-together/services/front-buy-together.service.ts
@@ -12,9 +12,10 @@ import { FrontBuyTogetherFilter } from './front-buy-together.filter';
 
 export class FrontBuyTogetherService implements IFrontBuyTogetherService {
   private buyTogetherPaymentConfig: BuyTogetherPaymentConfig[];
+  private configLoaded: Promise<void>;
 
   constructor() {
-    this.loadBuyTogetherPaymentConfig();
+    this.configLoaded = this.loadBuyTogetherPaymentConfig();
   }
 
   private async loadBuyTogetherPaymentConfig() {
@@ -40,6 +41,7 @@ export class FrontBuyTogetherService implements IFrontBuyTogetherService {
     productId: number,
     variationId?: number,
   ): Promise<IBuyTogetherComponentData> {
+    await this.configLoaded;
     const responseData = await BuyTogetherService.getByProductIdWithValidPromotionDate(productId);
     if (!responseData) return null;
     const buyTogetherData = new FrontBuyTogetherFilter(responseData);


### PR DESCRIPTION
## Resumo
- Corrige falha intermitente na exibição do **Compre Junto** no primeiro carregamento (principalmente quando a variação vem definida na URL), que resultava em tela em branco e erro no console.

Issue: https://git.tray.net.br/bagy/board-falhas/-/issues/95

## Causa raiz
- **Race condition** no `FrontBuyTogetherService`:
  - o `constructor()` disparava o carregamento assíncrono da configuração de pagamentos (`loadBuyTogetherPaymentConfig`) **sem aguardar**;
  - em alguns carregamentos, `getBuyTogetherByProductId()` era executado antes da configuração estar pronta;
  - isso fazia `buyTogetherPaymentConfig` ficar `undefined`, e o adapter quebrava com:
    - `TypeError: Cannot read properties of undefined (reading 'every')`

<img width="679" height="43" alt="image" src="https://github.com/user-attachments/assets/ac3c0874-a4d4-47db-9576-cc4690328b4d" />

## O que foi alterado
- Inicialização assíncrona via Promise:
  - adicionada `configLoaded: Promise<void>`
  - o `constructor()` passa a guardar a Promise do carregamento
  - `getBuyTogetherByProductId()` faz `await this.configLoaded` antes de adaptar/usar `buyTogetherPaymentConfig`

## Impacto no comportamento
- Em vez de “quebrar” e ficar em branco, o componente pode **permanecer no loader** até a config estar carregada e então renderizar corretamente.
- Mantém a regra desejada: **ou renderiza com preço/config corretos, ou não renderiza**

## Como testar
- **Cenário real (homolog/prod):**
  - Acessar uma página com variação na URL (ex.: `?variation=...`) em múltiplos refreshes/abas anônimas.
  - Confirmar que o erro `reading 'every'` não aparece mais e o Compre Junto renderiza quando há promoção ativa.

- **Cenário local (reprodução do bug):**
  - (Apenas para simular) inserir um delay no `loadBuyTogetherPaymentConfig()` e recarregar a página.
  - Antes do fix: o erro acontece.
  - Depois do fix: o componente aguarda e renderiza após o carregamento.

## Risco
- Baixo: mudança pontual, sem alterar contrato público do componente; apenas garante ordem correta de inicialização.

